### PR TITLE
Modified chat archiver plugin to use new chatlogs directory.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -76,6 +76,7 @@ public class RuneLite
 	public static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".runelite");
 	public static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles");
 	public static final File SCREENSHOT_DIR = new File(RUNELITE_DIR, "screenshots");
+	public static final File CHATLOG_DIR = new File(RUNELITE_DIR, "chatlogs");
 	private static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	private static final File LOGS_FILE_NAME = new File(LOGS_DIR, "application");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatarchiver/ChatArchiverFileIO.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatarchiver/ChatArchiverFileIO.java
@@ -6,24 +6,27 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 
+import static net.runelite.client.RuneLite.CHATLOG_DIR;
+
 public class ChatArchiverFileIO {
-    private static final String path = "./runelite-client/src/main/resources/net/runelite/client/plugins/chatarchiver/players/";
 
     private static Gson gson;
     private FileWriter fw;
     private BufferedWriter bw;
     private String player;
     private ArrayList<ArchivedMessage> playerMessages;
+    private static final File chatlogDir = CHATLOG_DIR;
 
     ChatArchiverFileIO() {
+        chatlogDir.mkdirs();
         this.gson = new Gson();
     }
+
     public HashSet<String> initGetPlayerNames()
     {
         HashSet<String> playerNames = new HashSet<String>();
-        File folder = new File(path);
         try {
-            for (File file : folder.listFiles()) {
+            for (File file : chatlogDir.listFiles()) {
                 if (file.isFile() && file.getAbsolutePath().toLowerCase().endsWith(".txt")) {
                     String playerName = file.getName().substring(0, file.getName().lastIndexOf('.'));
                     playerNames.add(playerName);
@@ -48,7 +51,7 @@ public class ChatArchiverFileIO {
             System.out.println("setting new writer: " + playerName);
             try
             {
-                fw = new FileWriter(path + playerName + ".txt",true);
+                fw = new FileWriter(new File(chatlogDir, playerName + ".txt"), true);
                 bw = new BufferedWriter(fw);
 
             }catch(IOException e)
@@ -82,7 +85,7 @@ public class ChatArchiverFileIO {
         FileReader fr = null;
         BufferedReader br = null;
         try {
-            fr = new FileReader(path + playerSelected + ".txt");
+            fr = new FileReader(new File(chatlogDir, playerSelected + ".txt"));
             br = new BufferedReader(fr);
 
             String curLine;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chatarchiver/ChatArchiverPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chatarchiver/ChatArchiverPanel.java
@@ -75,6 +75,7 @@ public class ChatArchiverPanel extends PluginPanel {
         container.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
         //dynamically sorts names as they get inserted
+        if (boxNames.length == 0) boxNames = new String[]{""};
         model = new SortedComboBoxModel(boxNames);
         comboBox = new JComboBox(model);
 


### PR DESCRIPTION
Previously it was dumping chatlogs into the source code repository.

This is the first time I've ever opened a pull request, and it involved about three separate repositories and one force push, but the end result appears to be correct, lol.

Now it dumps the chat logs into a new chatlog directory, adjacent to the screenshots directory.

I also had to ensure that the boxNames array wasn't empty when it was used. There may be a better way to do that, unsure.